### PR TITLE
Wait on queue condition

### DIFF
--- a/access.cpp
+++ b/access.cpp
@@ -1038,6 +1038,8 @@ int DemuxHTSP(demux_t *demux)
 
     vlc_mutex_lock(&sys->queueMutex);
     if(sys->msgQueue.size() == 0)
+        vlc_cond_wait(&sys->queueCond, &sys->queueMutex);
+    if(sys->msgQueue.size() == 0)
     {
         vlc_mutex_unlock(&sys->queueMutex);
         return DEMUX_OK;


### PR DESCRIPTION
Commit 9f0441a ("Move sending pause/seek requests into the thread to
avoid problems") dropped the vlc_cond_wait() call, resulting in a busy
loop when waiting for new messages.

Signed-off-by: Sven Wegener sven.wegener@stealer.net
