### PR TITLE
Missed a check that assumes sequential stream indices.

### DIFF
--- a/access.cpp
+++ b/access.cpp
@@ -905,7 +905,7 @@ bool ParseMuxPacket(demux_t *demux, HtsMessage &msg)
         return false;
     }
 
-    if(index > sys->streamCount || index == 0)
+    if(index == 0)
     {
         free(bin);
         msg_Err(demux, "Invalid stream index detected: %d with %d streams", index, sys->streamCount);


### PR DESCRIPTION
Not sure how it managed to work when I tested the previous change, but I'd missed this if statement. With this if statement still in, playback failed almost immediately. I can only assume that when I tested it no packets in the problem stream index where being sent.