### PR TITLE
Quote $DESTDIR, $plugindir when passing to shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,14 @@ CXX_SOURCES = vlc-htsp-plugin.cpp htsmessage.cpp helper.cpp access.cpp discovery
 all: libhtsp_plugin.so
 
 install: all
-	mkdir -p -- $(DESTDIR)$(plugindir)/access
-	$(INSTALL) --mode 0755 libhtsp_plugin.so $(DESTDIR)$(plugindir)/access
+	mkdir -p -- "$(DESTDIR)$(plugindir)/access"
+	$(INSTALL) --mode 0755 libhtsp_plugin.so "$(DESTDIR)$(plugindir)/access"
 
 install-strip:
 	$(MAKE) install INSTALL="$(INSTALL) -s"
 
 uninstall:
-	rm -f $(plugindir)/codec/libhtsp_plugin.so
+	rm -f "$(plugindir)/codec/libhtsp_plugin.so"
 
 clean:
 	rm -f -- libhtsp_plugin.{dll,so} *.o


### PR DESCRIPTION
Need to quote $DESTDIR and $plugindir so that spaces are preserved for paths.