### PR TITLE
Make seeking more reliable so such that audio now works after a seek

### DIFF
--- a/access.cpp
+++ b/access.cpp
@@ -1040,12 +1040,13 @@ bool ParseSubscriptionSkip(demux_t *demux, HtsMessage &msg)
 
     msg_Info(demux, "SubscriptionSkip: newTime: %lld, base: %s", (long long int)newTime, (msg.getRoot()->getU32("absolute"))?"abs":"rel");
 
-    es_out_Control(demux->out, ES_OUT_SET_PCR, VLC_TS_0 + newTime);
+    es_out_Control(demux->out, ES_OUT_RESET_PCR);
 
     msg_Info(demux, "PCR Reset done");
 
-    sys->lastPcr = newTime;
-    sys->currentPcr = newTime;
+    sys->lastPcr = 0;
+    sys->currentPcr = 0;
+
     sys->tsOffset = 0;
 
     return true;


### PR DESCRIPTION
Using vlc 2.2.1 I can now seek backward and forward in the timeshift buffer and audio now restarts. Previously video would play but I would get no audio after a seek.
